### PR TITLE
Fixed fullscreen camera width and height positioning

### DIFF
--- a/src/notval/Components/TestCamera.cpp
+++ b/src/notval/Components/TestCamera.cpp
@@ -1,8 +1,6 @@
 #include "Components.hpp"
 
-Camera::Camera(GameObject* gameObject) : Component(gameObject) {
-	m_AspectRatio = static_cast<double>(Screen.GetScreenWidth()) / static_cast<double>(Screen.GetScreenHeight());
-}
+Camera::Camera(GameObject* gameObject) : Component(gameObject) { }
 
 std::unique_ptr<Component> Camera::Clone() const {
 	return std::make_unique<Camera>(*this);
@@ -10,7 +8,7 @@ std::unique_ptr<Component> Camera::Clone() const {
 
 Vector2D Camera::GetUnitsOnScreen() const { 
 	return Vector2D(
-		defaultUnitsY * m_AspectRatio * transform->scale.x, 
+		defaultUnitsY * Screen.GetAspectRatio() * transform->scale.x,
 		defaultUnitsY * transform->scale.y
 	);
 }

--- a/src/notval/Core.hpp
+++ b/src/notval/Core.hpp
@@ -622,8 +622,6 @@ private:
     friend class RenderingHandler;
 };
 
-// CODE ABOVE IS REVIEWED
-
 class InputHandler {
 public:
     bool GetKey(const SDL_Scancode scanCode) const;
@@ -671,12 +669,15 @@ private:
     SDL_Window* m_Window;
     SDL_DisplayMode m_Mode{};
     int m_Width{}, m_Height{};
+    int m_InitWidth{}, m_InitHeight{};
 
     friend class Object;
     friend class Engine2D;
     friend class RenderingHandler;
     friend class TimeHandler;
 };
+
+// CODE ABOVE IS REVIEWED
 
 class TextureHandler : public Object {
 public:

--- a/src/notval/Core.hpp
+++ b/src/notval/Core.hpp
@@ -660,7 +660,10 @@ public:
     void SetResolution(const int w, const int h);
     inline unsigned int GetScreenWidth() const { return m_Width; }
     inline unsigned int GetScreenHeight() const { return m_Height; }
+    inline double GetAspectRatio() const { return m_AspectRatio; }
     inline bool InFocus() const { return (SDL_GetWindowFlags(m_Window) & (SDL_WINDOW_MINIMIZED | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS)); };
+    inline bool IsFullscreen() const { return SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN; }
+
 private:
     ScreenHandler();
 
@@ -670,6 +673,7 @@ private:
     SDL_DisplayMode m_Mode{};
     int m_Width{}, m_Height{};
     int m_InitWidth{}, m_InitHeight{};
+    double m_AspectRatio;
 
     friend class Object;
     friend class Engine2D;

--- a/src/notval/Core.hpp
+++ b/src/notval/Core.hpp
@@ -508,7 +508,6 @@ private:
 
     Vector2D GetUnitsOnScreen() const;
 
-    double m_AspectRatio;
     static constexpr uint8_t defaultUnitsY = 10;
 
     friend class GameObject;

--- a/src/notval/ScreenHandler.cpp
+++ b/src/notval/ScreenHandler.cpp
@@ -4,17 +4,19 @@
 ScreenHandler::ScreenHandler() : m_Window(nullptr) { }
 
 void ScreenHandler::ToggleFullscreen() {
-	if (!(SDL_GetWindowFlags(m_Window) & SDL_WINDOW_FULLSCREEN)) {
-		SDL_SetWindowSize(m_Window, m_Mode.w, m_Mode.h); 
+	if (!IsFullscreen()) {
+		SetResolution(m_Mode.w, m_Mode.h);
 		SDL_SetWindowFullscreen(m_Window, SDL_WINDOW_FULLSCREEN);
 		return;
 	}
 
-	SDL_SetWindowSize(m_Window, m_Width, m_Height);
 	SDL_SetWindowFullscreen(m_Window, 0);
+	SetResolution(m_InitWidth, m_InitHeight);
 }
 
 void ScreenHandler::SetResolution(const int w, const int h) {
+	m_Width = w;
+	m_Height = h;
 	SDL_SetWindowSize(m_Window, w, h);
 	SDL_SetWindowPosition(m_Window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }
@@ -31,6 +33,7 @@ bool ScreenHandler::InitScreen(const char* title, const char* iconpath, const in
 	m_InitHeight = windowHeight;
 	m_Width = windowWidth;
 	m_Height = windowHeight;
+	m_AspectRatio = static_cast<double>(m_Width) / static_cast<double>(m_Height);
 
 	if (!(m_Window = SDL_CreateWindow(title, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, 0))) {
 		std::cout << "Error: Couldn't Initialize Window..." << std::endl;

--- a/src/notval/ScreenHandler.cpp
+++ b/src/notval/ScreenHandler.cpp
@@ -27,6 +27,8 @@ bool ScreenHandler::InitScreen(const char* title, const char* iconpath, const in
 		std::cout << "Stage: Display Mode Initialized..." << std::endl;
 	}
 
+	m_InitWidth = windowWidth;
+	m_InitHeight = windowHeight;
 	m_Width = windowWidth;
 	m_Height = windowHeight;
 

--- a/src/notval/ScreenHandler.cpp
+++ b/src/notval/ScreenHandler.cpp
@@ -17,6 +17,7 @@ void ScreenHandler::ToggleFullscreen() {
 void ScreenHandler::SetResolution(const int w, const int h) {
 	m_Width = w;
 	m_Height = h;
+	m_AspectRatio = static_cast<double>(m_Width) / static_cast<double>(m_Height);
 	SDL_SetWindowSize(m_Window, w, h);
 	SDL_SetWindowPosition(m_Window, SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED);
 }


### PR DESCRIPTION
Now whenever toggle fullscreen or set resolution is called, it updates the width and height members of the screen so that the camera always accesses the updated version of the screen's dimensions including aspect ratio which is moved away from camera, into the screen.